### PR TITLE
Revert if users send both Ether and tokens

### DIFF
--- a/contracts/bounty/BountyIndex.sol
+++ b/contracts/bounty/BountyIndex.sol
@@ -64,7 +64,7 @@ contract BountyIndex {
     uint _expirationTimeDelta,
     string memory _metaData
     ) payable public returns (bool) {
-
+    require(_tokenAddress == 0x0 || msg.value == 0)
     //transfer funds
     if(_tokenAddress != 0x0){
       //ERC20 token


### PR DESCRIPTION
This require checks that if a token address is provided, there are no ethers in the transaction.
Note that the code already guarantees that if there is no token address, there are some ethers.

This fix avoids the case where the contract receive ethers but do not record them in a bounty because a token address was provided.