### PR TITLE
Update to use the official truffle ganache-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Check out the issues board or the [Gitcoin Bounty Explorer](https://gitcoin.co/e
 ## Testrpc Docker service
 
 Run testrpc in docker container
-`docker-compose up -d testrpc`
+`docker-compose up -d`
 
 # Deployed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
 version: '2'
 
 services:
-
     testrpc:
-        build:
-            context: ./testrpc
+        image: trufflesuite/ganache-cli
         ports:
            - "8545:8545"

--- a/testrpc/Dockerfile
+++ b/testrpc/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:7.10.1-wheezy
-
-MAINTAINER Peter Lai <alk03073135@gmail.com>
-
-RUN npm install -g ethereumjs-testrpc@4.0.0
-
-CMD testrpc --hostname=0.0.0.0 8545


### PR DESCRIPTION
The goal of this PR is to replace the custom Dockerfile with the official testrpc/ganace-cli image provided via docker hub.